### PR TITLE
update unit test survDataCheck with unit test for timeInteger #25 [survival]

### DIFF
--- a/R/morse-internal.R
+++ b/R/morse-internal.R
@@ -291,7 +291,6 @@ survFullPlotL <- function(data, xlab, ylab, addlegend) {
   }
 }
 
-#' @import ggplot2
 survFullPlotGG <- function(data, xlab, ylab, addlegend) {
   # plot of survival data: one subplot for each concentration, and one color for
   # each replicate for ggplot type

--- a/R/plot.survData.R
+++ b/R/plot.survData.R
@@ -137,7 +137,6 @@ survDataPlotFullLattice <- function(data, xlab, ylab, addlegend) {
   }
 }
 
-#' @import ggplot2
 survDataPlotFullGG <- function(data, xlab, ylab, addlegend) {
   # plot of survival data: one subplot for each concentration, and one color for
   # each replicate for ggplot graphics
@@ -206,8 +205,6 @@ survDataPlotFull <- function(data,
 #'
 #'#' @examples
 #'
-#' library(ggplot2)
-#'
 #' # (1) Load the data
 #' data(zinc)
 #' zinc <- survData(zinc)
@@ -227,7 +224,6 @@ survDataPlotFull <- function(data,
 
 #' @export
 #'
-#' @import ggplot2
 #' @import grDevices
 # FIXME: delete imports if really not needed
 # @importFrom gridExtra grid.arrange arrangeGrob

--- a/tests/testthat/test-surv.R
+++ b/tests/testthat/test-surv.R
@@ -89,11 +89,6 @@ test_that("survDataCheck", {
   expect_equal(survDataCheck(zinc9, diagnosis.plot = FALSE)$id[4],
                "ReplicateLabel")
   
-  zinc10 <- zinc
-  zinc10[46, "time"]
-  expect_equal(survDataCheck(zinc10, diagnosis.plot = FALSE)$id,
-               "timeInteger")
-  
   cadmium19 <- cadmium1
   cadmium19[12, "replicate"] <- 5
   expect_equal(survDataCheck(cadmium19, diagnosis.plot = FALSE)$id[4],

--- a/tests/testthat/test-surv.R
+++ b/tests/testthat/test-surv.R
@@ -12,58 +12,6 @@ d <- list(cadmium1 = cadmium1,
           chlordan = chlordan,
           zinc = zinc)
 
-# error dataset
-
-zinc0 <- as.list(zinc)
-
-zinc1 <- zinc
-colnames(zinc1) <- c("replica", "con", "time", "Nsur", "Nrepro")
-
-zinc2 <- zinc
-zinc2[46, "time"] <- 1
-zinc2$time <- as.integer(zinc2$time)
-
-zinc3 <- zinc
-zinc3$conc <- as.character(zinc3$conc)
-
-zinc4 <- zinc
-zinc4$Nsurv <- as.numeric(zinc4$Nsurv)
-
-zinc5 <- zinc
-zinc5[69, "Nsurv"] <- -248
-zinc5$Nsurv <- as.integer(zinc5$Nsurv)
-
-zinc6 <- zinc
-zinc6[1, "Nsurv"] <- 0
-zinc6$Nsurv <- as.integer(zinc6$Nsurv)
-
-zinc7 <- zinc
-zinc7[107, "replicate"] <- "A"
-
-zinc8 <- zinc
-zinc8[25, "Nsurv"] <- 20
-zinc8$Nsurv <- as.integer(zinc8$Nsurv)
-
-zinc9 <- zinc
-zinc9[, "replicate"] <- as.character(zinc9[, "replicate"])
-zinc9[12, "replicate"] <- "D"
-zinc9[, "replicate"] <- as.factor(zinc9[, "replicate"])
-
-cadmium19 <- cadmium1
-cadmium19[12, "replicate"] <- 5
-
-d2 <- list(zinc0 = zinc0,
-           zinc1 = zinc1,
-           zinc2 = zinc2,
-           zinc3 = zinc3,
-           zinc4 = zinc4,
-           zinc5 = zinc5,
-           zinc6 = zinc6,
-           zinc7 = zinc7,
-           zinc8 = zinc8,
-           zinc9 = zinc9,
-           cadmium19 = cadmium19)
-
 ## tests
 
 test_that("survDataCheck", {
@@ -78,45 +26,76 @@ test_that("survDataCheck", {
                      "data.frame"))
     expect_null(dat$id)
     expect_null(dat$msg)
-    })
+  })
   
   # error dataset
-  expect_named(survDataCheck(d2[["zinc0"]],
-                             diagnosis.plot = FALSE), c("id", "msg"))
-  
-  expect_equal(survDataCheck(d2[["zinc0"]],
+  zinc0 <- as.list(zinc)
+  expect_named(survDataCheck(zinc0,
+                             diagnosis.plot = FALSE), c("id", "msg"))  
+  expect_equal(survDataCheck(zinc0,
                              diagnosis.plot = FALSE)$id,
                "dataframeExpected")
   
-  expect_equal(survDataCheck(d2[["zinc1"]],
-                              diagnosis.plot = FALSE)$id,
+  zinc1 <- zinc
+  colnames(zinc1) <- c("replica", "con", "time", "Nsur", "Nrepro")  
+  expect_equal(survDataCheck(zinc1,
+                             diagnosis.plot = FALSE)$id,
                rep("missingColumn", 3))
   
-  expect_equal(survDataCheck(d2[["zinc2"]],
-                              diagnosis.plot = FALSE)$id[1],
+  zinc2 <- zinc
+  zinc2[46, "time"] <- 1
+  zinc2$time <- as.integer(zinc2$time)
+  expect_equal(survDataCheck(zinc2,
+                             diagnosis.plot = FALSE)$id[1],
                "firstTime0")
   
-  expect_equal(survDataCheck(d2[["zinc3"]], diagnosis.plot = FALSE)$id,
+  zinc3 <- zinc
+  zinc3$conc <- as.character(zinc3$conc)
+  expect_equal(survDataCheck(zinc3, diagnosis.plot = FALSE)$id,
                "concNumeric")
   
-  expect_equal(reproDataCheck(d2[["zinc4"]], diagnosis.plot = FALSE)$id,
+  zinc4 <- zinc
+  zinc4$Nsurv <- as.numeric(zinc4$Nsurv)
+  expect_equal(reproDataCheck(zinc4, diagnosis.plot = FALSE)$id,
                "NsurvInteger")
   
-  expect_equal(reproDataCheck(d2[["zinc5"]], diagnosis.plot = FALSE)$id[1],
+  zinc5 <- zinc
+  zinc5[69, "Nsurv"] <- -248
+  zinc5$Nsurv <- as.integer(zinc5$Nsurv)
+  expect_equal(reproDataCheck(zinc5, diagnosis.plot = FALSE)$id[1],
                "tablePositive")
   
-  expect_equal(survDataCheck(d2[["zinc6"]], diagnosis.plot = FALSE)$id[1],
+  zinc6 <- zinc
+  zinc6[1, "Nsurv"] <- 0
+  zinc6$Nsurv <- as.integer(zinc6$Nsurv)
+  expect_equal(survDataCheck(zinc6, diagnosis.plot = FALSE)$id[1],
                "Nsurv0T0")
   
-  expect_equal(survDataCheck(d2[["zinc7"]], diagnosis.plot = FALSE)$id[1:2],
+  zinc7 <- zinc
+  zinc7[107, "replicate"] <- "A"
+  expect_equal(survDataCheck(zinc7, diagnosis.plot = FALSE)$id[1:2],
                c("duplicatedID", "missingReplicate"))
   
-  expect_equal(survDataCheck(d2[["zinc8"]], diagnosis.plot = FALSE)$id,
+  zinc8 <- zinc
+  zinc8[25, "Nsurv"] <- 20
+  zinc8$Nsurv <- as.integer(zinc8$Nsurv)
+  expect_equal(survDataCheck(zinc8, diagnosis.plot = FALSE)$id,
                "NsurvIncrease")
   
-  expect_equal(survDataCheck(d2[["zinc9"]], diagnosis.plot = FALSE)$id[4],
+  zinc9 <- zinc
+  zinc9[, "replicate"] <- as.character(zinc9[, "replicate"])
+  zinc9[12, "replicate"] <- "D"
+  zinc9[, "replicate"] <- as.factor(zinc9[, "replicate"])
+  expect_equal(survDataCheck(zinc9, diagnosis.plot = FALSE)$id[4],
                "ReplicateLabel")
   
-  expect_equal(survDataCheck(d2[["cadmium19"]], diagnosis.plot = FALSE)$id[4],
+  zinc10 <- zinc
+  zinc10[46, "time"]
+  expect_equal(survDataCheck(zinc10, diagnosis.plot = FALSE)$id,
+               "timeInteger")
+  
+  cadmium19 <- cadmium1
+  cadmium19[12, "replicate"] <- 5
+  expect_equal(survDataCheck(cadmium19, diagnosis.plot = FALSE)$id[4],
                "ReplicateLabel")
 })

--- a/tests/testthat/test-surv.R
+++ b/tests/testthat/test-surv.R
@@ -89,6 +89,11 @@ test_that("survDataCheck", {
   expect_equal(survDataCheck(zinc9, diagnosis.plot = FALSE)$id[4],
                "ReplicateLabel")
   
+  zinc10 <- zinc
+  zinc10[46, "time"] <- "A"
+  expect_equal(survDataCheck(zinc10, diagnosis.plot = FALSE)$id[2],
+               "timeNumeric")
+  
   cadmium19 <- cadmium1
   cadmium19[12, "replicate"] <- 5
   expect_equal(survDataCheck(cadmium19, diagnosis.plot = FALSE)$id[4],


### PR DESCRIPTION
reorganised survDataCheck unit test with new unit test for `timeInteger` error (on next PR)