### PR TITLE
Newplots proposal [repro]

### DIFF
--- a/R/morse-internal.R
+++ b/R/morse-internal.R
@@ -291,7 +291,6 @@ survFullPlotL <- function(data, xlab, ylab, addlegend) {
   }
 }
 
-#' @import ggplot2
 survFullPlotGG <- function(data, xlab, ylab, addlegend) {
   # plot of survival data: one subplot for each concentration, and one color for
   # each replicate for ggplot type

--- a/R/plot.survData.R
+++ b/R/plot.survData.R
@@ -137,7 +137,6 @@ survDataPlotFullLattice <- function(data, xlab, ylab, addlegend) {
   }
 }
 
-#' @import ggplot2
 survDataPlotFullGG <- function(data, xlab, ylab, addlegend) {
   # plot of survival data: one subplot for each concentration, and one color for
   # each replicate for ggplot graphics
@@ -227,7 +226,6 @@ survDataPlotFull <- function(data,
 
 #' @export
 #'
-#' @import ggplot2
 #' @import grDevices
 # FIXME: delete imports if really not needed
 # @importFrom gridExtra grid.arrange arrangeGrob

--- a/R/reproData.R
+++ b/R/reproData.R
@@ -55,13 +55,13 @@
 #'
 #' @export
 #'
-reproData <- function(data) {
+reproData <- function(data, firstTimeClutch = NULL) {
 
   # test the integrity of the data with reproDataCheck
   if (dim(reproDataCheck(data))[1] > 0)
     stop("The [data] argument is not well-formed, please use [reproDataCheck] for details.")
 
-  data <- survData(data)
+  data <- survData(data, firstTimeClutch)
 
   T <- sort(unique(data$time)) # observation times
   Nreprocumul <- data$Nrepro
@@ -71,7 +71,7 @@ reproData <- function(data) {
     Nreprocumul[now] <- Nreprocumul[before] + data$Nrepro[now]
   }
 
-  data <- cbind(data,Nreprocumul)
+  data <- cbind(data, Nreprocumul)
   class(data) <- c("reproData", "survData","data.frame")
   return(data)
 }

--- a/R/survData.R
+++ b/R/survData.R
@@ -113,8 +113,8 @@ survData <- function(data, firstTimeClutch = NULL) {
       data <- data[data$time >= firstTimeClutch,]
       
     } else { # firstimeclutch is not one of the observed time
-      lstprevioustime <- max(unique(data[data$time < firstTimeClutch, "time"]))
-      data <- data[c(which(data$time == lstprevioustime),
+      lstPreviousTime <- max(unique(data[data$time < firstTimeClutch, "time"]))
+      data <- data[c(which(data$time == lstPreviousTime),
                      which(data$time >= firstTimeClutch)),]
     }
   
@@ -130,15 +130,17 @@ survData <- function(data, firstTimeClutch = NULL) {
 
   T <- sort(unique(out$time)) # observation times
   Nindtime <- rep(0, dim(out)[1])
+  NindtimeNoCumul <- rep(0, dim(out)[1])
   for (i in 2:length(T)) {
     now <- out$time == T[i]
     before <- out$time == T[i - 1]
     Nindtime[now] <- Nindtime[before] +
       (out$Nsurv[before] - out$Nsurv[now]) * ((T[i] - T[i - 1]) / 2) +
       out$Nsurv[now] * (T[i] - T[i - 1])
+    NindtimeNoCumul[now] <- Nindtime[now] - Nindtime[before]
   }
 
-  out <- cbind(out, Nindtime)
+  out <- cbind(out, Nindtime, NindtimeNoCumul)
 
   class(out) <- c("survData", "data.frame")
   return(out)

--- a/R/survData.R
+++ b/R/survData.R
@@ -26,6 +26,7 @@
 #' \item \code{Nsurv}: a vector of class \code{integer} providing the number of
 #' alive individuals at each time point for each concentration and each replicate
 #' }
+#' @param firstTimeClutch the first day of reproduction activity
 # FIXME @param x An object of class survData.
 # FIXME @param object An object of class survData.
 #' @param \dots Further arguments to be passed to generic methods.
@@ -62,7 +63,7 @@
 #' @export
 #' @importFrom dplyr left_join rename
 # @importFrom plyr rename
-survData <- function(data) {
+survData <- function(data, firstTimeClutch = NULL) {
   ### INPUT
   # [data]: a [data.frame] with above mentionned requirements
   #
@@ -84,21 +85,60 @@ survData <- function(data) {
 
   Nsurv <- c() # this is needed to avoid a complaint from package check when
                # using dplyr::rename. R is such a sad language.
+
+  # select the start time to calculat NID
+  if (is.null(firstTimeClutch)) { # default firstTimeClutch
+    firstTimeClutch <- 0
+  }
+  
+  # estimate first clutch observed time
+  beforeObservedCluthTime <- min(unique(data[!unlist(lapply(split(data, data$time),
+                                 function(x) {all(x$Nrepro == 0)})),
+                                             "time"])) - 1
+  
+  if (beforeObservedCluthTime < 0) {
+    beforeObservedCluthTime <- 0
+  }
+  
+  # save original time for graph
+  data$timeOrigine <- data$time
+  
+  if (firstTimeClutch > beforeObservedCluthTime)
+    stop("The selected time is equal or higger than the first time where clutches are
+         oberved !")
+  
+  if (firstTimeClutch != 0) { # selected firstime clutch
+    if (firstTimeClutch %in% unique(data$time)) { # firstTimeClutch is one of the
+      # oberserved time
+      data <- data[data$time >= firstTimeClutch,]
+      
+    } else { # firstimeclutch is not one of the observed time
+      lstprevioustime <- max(unique(data[data$time < firstTimeClutch, "time"]))
+      data <- data[c(which(data$time == lstprevioustime),
+                     which(data$time >= firstTimeClutch)),]
+    }
+  
+    # change first time to 0
+    data[data$time == min(data$time), "time"] <- 0
+    # change other time
+    data[data$time != 0, "time"] <- data[data$time != 0, "time"] - firstTimeClutch
+  }
+  
   data.t0 <- data[data$time == 0, c("replicate", "conc", "Nsurv")]
   data.t0 <- rename(data.t0, Ninit = Nsurv)
   out <- left_join(data, data.t0, by = c("replicate", "conc"))
 
-  T <- sort(unique(data$time)) # observation times
-  Nindtime <- rep(0,dim(data)[1])
+  T <- sort(unique(out$time)) # observation times
+  Nindtime <- rep(0, dim(out)[1])
   for (i in 2:length(T)) {
-    now <- data$time == T[i]
-    before <- data$time == T[i - 1]
+    now <- out$time == T[i]
+    before <- out$time == T[i - 1]
     Nindtime[now] <- Nindtime[before] +
-      (data$Nsurv[before] - data$Nsurv[now]) * ((T[i] - T[i - 1]) / 2) +
-      data$Nsurv[now] * (T[i] - T[i - 1])
+      (out$Nsurv[before] - out$Nsurv[now]) * ((T[i] - T[i - 1]) / 2) +
+      out$Nsurv[now] * (T[i] - T[i - 1])
   }
 
-  data <- cbind(data, Nindtime)
+  out <- cbind(out, Nindtime)
 
   class(out) <- c("survData", "data.frame")
   return(out)


### PR DESCRIPTION
this update of the functions `reproData` and `survData` suggest a new argument for these two functions:
`firstTimeClutch`. This argument is use to take into account in the calculation of `Nindtime`and `Nreprocumul` the first time when reproduction is obseved by removing the first timepoints where individuals are not mature.
This update is usefull in the reprsentation of the reproduction rate in function of  the time per concentration.
