### PR TITLE
Bugfix to avoid NAs in Surv.SD_Cext()

### DIFF
--- a/R/predict.survFit.R
+++ b/R/predict.survFit.R
@@ -235,7 +235,7 @@ Surv.SD_Cext <- function(Cw, time, kk, kd, z, hb){
   
   lambda = kk * pmax(D-z,0) + hb # the pmax function is important here for elementwise maximum with 0 and D[i,j]-z ATTENTION: pmax(0,D) != pmax(D,0)
   
-  lambda.prec = dplyr::lag(lambda, 1 ) ; lambda.prec[1] = lambda[1]
+  lambda.prec = dplyr::lag(lambda[1,], 1 ) ; lambda.prec[1] = lambda[1]
   
   int.lambda =  t(t((lambda + lambda.prec)/2) * (time-time.prec))
   


### PR DESCRIPTION
Current versions of dplyr::lag() work differently and no longer interpret matrix arguments as intended. This results in NAs being introduced in Surv.SD_Cext(). The attached patch fixes that.